### PR TITLE
Remove quizzes from Quizzes useEffect array

### DIFF
--- a/src/Kambaz/Courses/Quizzes/index.tsx
+++ b/src/Kambaz/Courses/Quizzes/index.tsx
@@ -23,7 +23,7 @@ export default function Quizzes() {
     };
     useEffect(() => {
         fetchQuizzes();
-    }, [quizzes]);
+    }, []);
 
     return (
         <div>


### PR DESCRIPTION
The useEffect handler in Quizzes/index.tsx was requesting a list of quizzes from the backend dozens of times a sec.

The reason seems to be that the list of quizzes `quizzes` was itself a dependency of the `useEffect`, so it was fetching quizzes from the server, updating the `quizzes` array, and in turn triggering the useEffect again.