### PR TITLE
Fix white screen problemo

### DIFF
--- a/src/Kambaz/Courses/Quizzes/Quiz/index.tsx
+++ b/src/Kambaz/Courses/Quizzes/Quiz/index.tsx
@@ -41,7 +41,6 @@ export default function Quiz() {
         const currentAttempt = await quizzesClient.findLatestQuizAttempt(
             qid as string
         );
-        console.log(currentAttempt);
         setAttempt(currentAttempt);
     };
     const fetchQuestions = async () => {
@@ -99,7 +98,7 @@ export default function Quiz() {
                     <br />
 
                     <hr />
-                    {totalAttempts > 0 && (
+                    {totalAttempts > 0 && Object.keys(attempt).length > 0 && (
                         <QuizAttempts attempt={attempt} questions={questions} />
                     )}
                 </>


### PR DESCRIPTION
Add a check to prevent the `QuizAttempts` component from rendering if the `attempt` object used by it has no keys.

Seems like there was a race condition where the QuizAttempts component would render before the fetching of attempts actually finished, making it render using an empty object. The thing that actually caused the white screen was the QuizAttempts component trying to read the object for answers.